### PR TITLE
WIP: Detail page for cafes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "dependencies": {
     "bootstrap": "^4.0.0-beta",
-    "mapbox-gl": "^0.43.0",
     "font-awesome": "^4.7.0",
+    "mapbox-gl": "^0.43.0",
     "react": "^16.1.1",
     "react-bootstrap": "^0.31.5",
     "react-bulma-components": "^0.1.8",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "dependencies": {
     "bootstrap": "^4.0.0-beta",
+    "instafeed.js": "^1.4.1",
+    "mapbox-gl": "^0.43.0",
     "react": "^16.1.1",
     "react-bootstrap": "^0.31.5",
     "react-bulma-components": "^0.1.8",

--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png" />
     <link rel="mask-icon" href="%PUBLIC_URL%/safari-pinned-tab.svg" color="#5bbad5" />
+    <link href='https://api.mapbox.com/mapbox-gl-js/v0.42.0/mapbox-gl.css' rel='stylesheet' />
     <title>Third Wave List</title>
   </head>
   <body>

--- a/src/App.js
+++ b/src/App.js
@@ -6,12 +6,11 @@ class App extends Component {
   render() {
     return (
       <div className="App">
-        <h1 className="title"><a className="no-style" href="/" alt="Home">Third Wave List</a></h1>
         <Routes />
         <div className="footer">
           <span>Made with <span role="img" aria-label="love">❤️</span> by <a className="no-style" href="https://www.twitter.com/tjalve">@tjalve</a> and <a className="no-style" href="https://www.twitter.com/anthonymonori">@anthonymonori</a>.</span>
           <br />
-          <span>Copyright (c). Third Wave List, 2017. All rights reserved.</span>
+          <span>Copyright (c). Third Wave List, 2017 - {new Date().getFullYear()}. All rights reserved.</span>
         </div>
       </div>
     );

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { Route, Switch } from "react-router-dom";
 import Home from "./containers/Home";
-import Manifesto from "./containers/Manifesto"
 import NotFound from "./containers/NotFound"
+import CafeDetail from "./containers/CafeDetail"
 
 export default () =>
   <Switch>
     <Route path="/" exact component={Home} />
-    <Route path="/manifesto" exact component={Manifesto} />
+    <Route path="/:city/:name" component={CafeDetail} />
     <Route component={NotFound} />
   </Switch>;

--- a/src/containers/CafeDetail.css
+++ b/src/containers/CafeDetail.css
@@ -35,6 +35,17 @@ span.subtitle {
     display: block;  
     margin-top: 20px;
 }
+span.social {
+    text-align: center;    
+    width: 100%; 
+    display: block;  
+}
+span.social a {
+    padding: 5px;
+    font-size: 2vw;
+    text-decoration: none !important;
+    color: inherit;
+}
 
 .col span.header {
     font-size: 18pt;

--- a/src/containers/CafeDetail.css
+++ b/src/containers/CafeDetail.css
@@ -1,0 +1,57 @@
+div .mapContainer {
+    position: relative;
+}
+
+.map {
+    width: 100%;
+    height: 22vw;
+}
+
+#direction-button {
+    position: absolute;
+    top: 90%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.direction > span {
+    font-style: bold;
+    font-weight: 600;
+}
+
+span.title {
+    text-align: center;    
+    width: 100%; 
+    font-size: 32pt;
+    color: #000;
+    display: block;  
+    margin-top: 20px;
+}
+span.subtitle {
+    text-align: center;    
+    width: 100%; 
+    font-size: 12pt;
+    color: #033;
+    display: block;  
+    margin-top: 20px;
+}
+
+.col span.header {
+    font-size: 18pt;
+    font-weight: 600;
+    color: black;
+}
+
+div.left {
+    width: 200px;
+    margin-left: auto;
+    margin-right: auto;
+    display: table;
+}
+
+div.right {
+    width: 200px;
+    margin-left: auto;
+    margin-right: auto;
+    display: table;
+}

--- a/src/containers/CafeDetail.css
+++ b/src/containers/CafeDetail.css
@@ -42,7 +42,7 @@ span.social {
 }
 span.social a {
     padding: 5px;
-    font-size: 2vw;
+    font-size: 2em;
     text-decoration: none !important;
     color: inherit;
 }

--- a/src/containers/CafeDetail.css
+++ b/src/containers/CafeDetail.css
@@ -40,7 +40,7 @@ span.social {
     width: 100%; 
     display: block;  
 }
-span.social a {
+span.social > a {
     padding: 5px;
     font-size: 2em;
     text-decoration: none !important;

--- a/src/containers/CafeDetail.css
+++ b/src/containers/CafeDetail.css
@@ -46,6 +46,10 @@ span.social > a {
     text-decoration: none !important;
     color: inherit;
 }
+span a {
+    text-decoration: none !important;
+    color: inherit;
+}
 
 .col span.header {
     font-size: 18pt;

--- a/src/containers/CafeDetail.js
+++ b/src/containers/CafeDetail.js
@@ -14,8 +14,6 @@ export default class CafeDetail extends Component {
 
       this.state = {
         isLoading: true,
-        cord_lat: "47.493755", // TODO: Remove hardcoded value
-        cord_lng: "19.060109", // TODO: Remove hardcoded value
         cafe: null
       }
     }
@@ -25,15 +23,15 @@ export default class CafeDetail extends Component {
             const cafeId = this.props.location.state.cafeId
             const cafeCallResponse = await this.cafeById(cafeId);
             this.setState({ cafe: cafeCallResponse });
-        } catch (e) {
+            this.setState({ isLoading: false });
+        } catch (err) {
             var pathSegments = this.props.location.pathname.split('/');
             const cafeName = pathSegments[1]
             const cityName = pathSegments[2]
             const cafeCallResponse = await this.cafeByName(cafeName, cityName);
             this.setState({ cafe: cafeCallResponse });
+            this.setState({ isLoading: false });
         }
-    
-        this.setState({ isLoading: false });
     }
 
     toggleFullscreen() {
@@ -69,20 +67,21 @@ export default class CafeDetail extends Component {
     }
 
     renderMapData(cafe) {
-        var lat = this.state.cord_lat;
-        var lng = this.state.cord_lng;
-        const mapContainer = <div className="absolute top right left bottom" />;
-        const map = new mapboxgl.Map({
-            container: this.container,
-            style: 'mapbox://styles/mapbox/streets-v9',
-            center: [lng, lat],
-            zoom: 14,
-            interactive: false
-        });
-        var marker = new mapboxgl.Marker()
-            .setLngLat([lng, lat])
-            .addTo(map);
-
+        if (cafe !== null) {
+            const lat = cafe.latlong.split(', ')[0];
+            const lng = cafe.latlong.split(', ')[1];
+            const mapContainer = <div className="absolute top right left bottom" />;
+            const map = new mapboxgl.Map({
+                container: this.container,
+                style: 'mapbox://styles/mapbox/streets-v9',
+                center: [lng, lat],
+                zoom: 14,
+                interactive: false
+            });
+            var marker = new mapboxgl.Marker()
+                .setLngLat([lng, lat])
+                .addTo(map);
+        }
         return <Button id="direction-button" color="primary" target="_blank" href={"https://www.google.com/maps/search/?api=1&query="+ cafe.city +"&query_place_id="+ cafe.extra_google_placeid}><span>Directions</span></Button>
     }
 

--- a/src/containers/CafeDetail.js
+++ b/src/containers/CafeDetail.js
@@ -71,7 +71,7 @@ export default class CafeDetail extends Component {
             .setLngLat([lng, lat])
             .addTo(map);
 
-        return <Button id="direction-button" color="primary" target="_blank" href="https://www.google.com/maps/search/?api=1&query={{this.state.cafe.name}}&query_place_id={{this.state.cafe.place_id}}"><span>Directions</span></Button>
+        return <Button id="direction-button" color="primary" target="_blank" href={"https://www.google.com/maps/search/?api=1&query="+ cafe.city +"&query_place_id="+ cafe.extra_google_placeid}><span>Directions</span></Button>
     }
 
     renderCafeDetails(cafe) {

--- a/src/containers/CafeDetail.js
+++ b/src/containers/CafeDetail.js
@@ -96,7 +96,7 @@ export default class CafeDetail extends Component {
                 </span>
                 <br />
                 <Columns breakpoint="desktop">
-                    <Col lg="6">
+                    <Col lg="4">
                         <div className="left"> 
                             <span className="header">Gear</span>
                             <br />
@@ -106,13 +106,22 @@ export default class CafeDetail extends Component {
                             {this.getPourOver(cafe)}
                         </div>
                     </Col>
-                    <Col lg="6">
+                    <br />
+                    <Col lg="4">
                         <div className="right">
                             <span className="header">Bean</span>
                             <br />
                             <div><span className="floatLeft"><b>Roaster(s) </b></span> <span className="floatRight">{cafe.bean_roaster}</span></div>
                             <div><span className="floatLeft"><b>Profile </b></span> <span className="floatRight">{this.getRoastProfile(cafe)}</span></div>
                             <div><span className="floatLeft"><b>Origin </b></span> <span className="floatRight">{this.getOrigin(cafe)}</span></div>
+                        </div>
+                    </Col>
+                    <br />
+                    <Col lg="4">
+                        <div className="right">
+                            <span className="header">Other</span>
+                            <br />
+                            <p>Store front photo by <b><a link="https://instagram.com/kristoffer_tjalve" alt="Instagram">Kristoffer</a></b></p>
                         </div>
                     </Col>
                 </Columns>
@@ -162,7 +171,7 @@ export default class CafeDetail extends Component {
 
     getFullImmersion(cafe) {
         if (cafe.brew_method_fullimmersion) {
-            return <div><span className="floatLeft"><b>Immersive </b></span> <span className="floatRight"> {cafe.gear_immersive}</span></div>
+            return <div><span className="floatLeft"><b>Extras </b></span> <span className="floatRight"> {cafe.gear_immersive}</span></div>
         }
         return;
     }

--- a/src/containers/CafeDetail.js
+++ b/src/containers/CafeDetail.js
@@ -22,11 +22,15 @@ export default class CafeDetail extends Component {
 
     async componentDidMount() {
         try {
-            var cafeId = this.props.location.state.cafeId
-            const cafeCallResponse = await this.cafe(cafeId);
+            const cafeId = this.props.location.state.cafeId
+            const cafeCallResponse = await this.cafeById(cafeId);
             this.setState({ cafe: cafeCallResponse });
         } catch (e) {
-            console.log(e);
+            var pathSegments = this.props.location.pathname.split('/');
+            const cafeName = pathSegments[1]
+            const cityName = pathSegments[2]
+            const cafeCallResponse = await this.cafeByName(cafeName, cityName);
+            this.setState({ cafe: cafeCallResponse });
         }
     
         this.setState({ isLoading: false });
@@ -35,10 +39,18 @@ export default class CafeDetail extends Component {
     toggleFullscreen() {
         console.log("fullscreen mode toggled");
     }
-    
-    cafe(cafeId) {
+
+    cafeById(cafeId) {
         return invokeApig({
             path: "/cafe/"+cafeId,
+            method: "GET",
+            headers: { "x-api-key": config.apiGateway.API_KEY }
+        });
+    }
+    
+    cafeByName(cafeName, cityName) {
+        return invokeApig({
+            path: "/"+cityName+"/"+cafeName,
             method: "GET",
             headers: { "x-api-key": config.apiGateway.API_KEY }
         });

--- a/src/containers/CafeDetail.js
+++ b/src/containers/CafeDetail.js
@@ -1,0 +1,154 @@
+import React, { Component } from 'react';
+import { invokeApig } from '../libs/awsLib'
+import { Button, Col } from 'reactstrap';
+import Columns from 'react-bulma-components/lib/components/columns';
+import config from '../config';
+import mapboxgl from 'mapbox-gl';
+import './CafeDetail.css';
+
+mapboxgl.accessToken = config.mapboxgl.ACCESS_TOKEN
+
+export default class CafeDetail extends Component {
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        isLoading: true,
+        cord_lat: "47.493755", // TODO: Remove hardcoded value
+        cord_lng: "19.060109", // TODO: Remove hardcoded value
+        cafe: null
+      }
+    }
+
+    async componentDidMount() {
+        try {
+            var cafeId = this.props.location.state.cafeId
+            const cafeCallResponse = await this.cafe(cafeId);
+            this.setState({ cafe: cafeCallResponse });
+        } catch (e) {
+            console.log(e);
+        }
+    
+        this.setState({ isLoading: false });
+    }
+
+    toggleFullscreen() {
+        console.log("fullscreen mode toggled");
+    }
+    
+    cafe(cafeId) {
+        return invokeApig({
+            path: "/cafe/"+cafeId,
+            method: "GET",
+            headers: { "x-api-key": config.apiGateway.API_KEY }
+        });
+    }
+
+    render() {
+        return(
+            <div>
+                <div className="mapContainer">
+                    <div className="map" ref={(x) => { this.container = x }} onClick={this.toggleFullscreen}/>
+                    {!this.state.isLoading && this.renderMapData(this.state.cafe)}
+                </div>
+                {!this.state.isLoading && this.renderCafeDetails(this.state.cafe)}
+            </div>
+        )
+    }
+
+    renderMapData(cafe) {
+        var lat = this.state.cord_lat;
+        var lng = this.state.cord_lng;
+        const mapContainer = <div className="absolute top right left bottom" />;
+        const map = new mapboxgl.Map({
+            container: this.container,
+            style: 'mapbox://styles/mapbox/streets-v9',
+            center: [lng, lat],
+            zoom: 14,
+            interactive: false
+        });
+        var marker = new mapboxgl.Marker()
+            .setLngLat([lng, lat])
+            .addTo(map);
+
+        return <Button id="direction-button" color="primary" target="_blank" href="https://www.google.com/maps/search/?api=1&query={{this.state.cafe.name}}&query_place_id={{this.state.cafe.place_id}}"><span>Directions</span></Button>
+    }
+
+    renderCafeDetails(cafe) {
+        return (
+            <div>
+                <span className="title">{cafe.name}</span>
+                <span className="subtitle">{cafe.city}, {cafe.address}</span>
+                <br />
+                <Columns breakpoint="desktop">
+                    <Col lg="6">
+                        <div className="left"> 
+                            <span className="header">Gear</span>
+                            <br />
+                            {this.getEspresso(cafe)}
+                            {this.getGrinder(cafe)}
+                            {this.getFullImmersion(cafe)}
+                            {this.getPourOver(cafe)}
+                        </div>
+                    </Col>
+                    <Col lg="6">
+                        <div className="right">
+                            <span className="header">Bean</span>
+                            <br />
+                            <div><span className="floatLeft"><b>Roaster(s) </b></span> <span className="floatRight">{cafe.bean_roaster}</span></div>
+                            <div><span className="floatLeft"><b>Profile </b></span> <span className="floatRight">{this.getRoastProfile(cafe)}</span></div>
+                            <div><span className="floatLeft"><b>Origin </b></span> <span className="floatRight">{this.getOrigin(cafe)}</span></div>
+                        </div>
+                    </Col>
+                </Columns>
+                <br />
+            </div>
+        )
+    }
+
+    getRoastProfile(cafe) {
+        var results = []
+        if (cafe.bean_roast_light) results.push("Light")
+        if (cafe.bean_roast_medium) results.push("Medium")
+        if (cafe.bean_roast_dark) results.push("Dark")
+        
+        if (results.length <= 1) {
+            return results.join();
+        } else {
+            return results.slice(0, -1).join(", ") + " and " + results[results.length-1];
+        }
+    }
+
+    getOrigin(cafe) {
+        if (cafe.bean_origin_single && cafe.bean_origin_blend) return "Single & Blend" 
+        else if (cafe.bean_origin_single) return "Single"
+        else if (cafe.bean_origin_blend) return "Blend"
+        else return "Unknown"
+    }
+
+    getGrinder(cafe) {
+        if (cafe.gear_grinder !== null && cafe.gear_grinder.length > 1) {
+            return <div><span className="floatLeft"><b>Grinder </b></span> <span className="floatRight">{cafe.gear_grinder}</span></div>
+        }
+    }
+    
+    getEspresso(cafe) {
+        if (cafe.brew_method_espresso && cafe.gear_espressomachine !== null && cafe.gear_espressomachine.length > 1) {
+            return <div><span className="floatLeft"><b>Espresso </b></span> <span className="floatRight">{cafe.gear_espressomachine}</span></div>
+        }
+        return
+    }
+
+    getPourOver(cafe) {
+        if (cafe.brew_method_pourover) {
+            return <div><span className="floatLeft"><b>Pour-over </b></span> <span className="floatRight">{cafe.gear_pourover}</span></div>
+        }
+    }
+
+    getFullImmersion(cafe) {
+        if (cafe.brew_method_fullimmersion) {
+            return <div><span className="floatLeft"><b>Immersive </b></span> <span className="floatRight"> {cafe.gear_immersive}</span></div>
+        }
+        return;
+    }
+}

--- a/src/containers/CafeDetail.js
+++ b/src/containers/CafeDetail.js
@@ -79,6 +79,10 @@ export default class CafeDetail extends Component {
             <div>
                 <span className="title">{cafe.name}</span>
                 <span className="subtitle">{cafe.city}, {cafe.address}</span>
+                <span className="social">
+                    {(cafe.social_instagram) ? <a className="fa fa-facebook-square" target="_blank" href={cafe.social_facebook}/> : null}
+                    {(cafe.social_instagram) ? <a className="fa fa-instagram" target="_blank" href={cafe.social_instagram}/> : null}
+                </span>
                 <br />
                 <Columns breakpoint="desktop">
                     <Col lg="6">

--- a/src/containers/CafeDetail.js
+++ b/src/containers/CafeDetail.js
@@ -121,7 +121,7 @@ export default class CafeDetail extends Component {
                         <div className="right">
                             <span className="header">Other</span>
                             <br />
-                            <p>Store front photo by <b><a link="https://instagram.com/kristoffer_tjalve" alt="Instagram">Kristoffer</a></b></p>
+                            <p>Store front photo by <b><a href="https://instagram.com/kristoffer_tjalve" alt="Instagram">Kristoffer</a></b></p>
                         </div>
                     </Col>
                 </Columns>

--- a/src/containers/CafeDetail.js
+++ b/src/containers/CafeDetail.js
@@ -121,7 +121,7 @@ export default class CafeDetail extends Component {
                         <div className="right">
                             <span className="header">Other</span>
                             <br />
-                            <p>Store front photo by <b><a href="https://instagram.com/kristoffer_tjalve" alt="Instagram">Kristoffer</a></b></p>
+                            <div><span>Store front photo by <b><a href="https://instagram.com/kristoffer_tjalve" alt="Instagram">Kristoffer</a></b></span></div>
                         </div>
                     </Col>
                 </Columns>

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -1,10 +1,11 @@
-import React, { Component } from "react";
-import { Col, Button } from "reactstrap";
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom'
+import { Col, Button } from 'reactstrap';
 import { Box, Container } from 'reactbulma'
 import Columns from 'react-bulma-components/lib/components/columns';
 import { invokeApig } from "../libs/awsLib";
-import "./Home.css";
 import config from "../config";
+import "./Home.css";
 
 /* global location */
 /* eslint no-restricted-globals: ["off", "location"] */
@@ -86,7 +87,12 @@ export default class Home extends Component {
           <div className="imageCard">
             <img src={cafe.extra_thumbnail} alt="Thumbnail" />
             <span className="imageTitle">{cafe.name}</span>
-            <div className="after" onClick={() => {location.href=this.getLinkFrom(cafe)}}>
+            {/* <div className="after" onClick={() => {location.href=this.getLinkFrom(cafe)}}> */}
+            <Link to = {{ 
+                pathname: '/'+cafe.city.toLowerCase()+'/'+cafe.name.replace(/\s+/g, '-').toLowerCase(),
+                state:{ cafeId: cafe.uid }
+              }}
+              className="after">
               <div className="center">
                 <span className="floatLeft"><b>Roast profile: </b></span> <span className="floatRight">{this.getRoastProfile(cafe)}</span>
                 <span className="floatLeft"><b>Roaster: </b></span> <span className="floatRight">{cafe.bean_roaster}</span>
@@ -96,7 +102,8 @@ export default class Home extends Component {
                 {this.getPourOver(cafe)}
                 {this.getFullImmersion(cafe)}
               </div>
-            </div>
+            {/* </div> */}
+            </Link>
           </div>
         </Col>
       );
@@ -299,88 +306,92 @@ export default class Home extends Component {
     }
 
     return (
-      <Container fluid>
-        <Box className="landing-container">
-          <Columns breakpoint="desktop">
-            <Columns.Column>
-              <div className='dropdown-block' onClick={this.toggleLocationDropdown}>
-                <label className='dropdown-label label'>
-                  <span>Where</span>
-                </label>
-                <a className='button'>
-                  <span>{this.state.locationFilter ? this.state.locationFilter.label : "Select a city"}</span>
-                </a>
-                <div className={"dropdown-container " + (this.state.locationDropdownOpen ? "is-open" : null)}>
-                  <div className='dropdown'>
-                    <button className='button label' data-arg1="all" data-arg2="All" onClick={this.setLocation}>All</button>    
-                    <button className='button label' data-arg1="budapest" data-arg2="Budapest" onClick={this.setLocation}>Budapest</button>
+      <div>
+        <h1 className="title"><a className="no-style" href="/" alt="Home">Third Wave List</a></h1>
+        
+        <Container fluid>
+          <Box className="landing-container">
+            <Columns breakpoint="desktop">
+              <Columns.Column>
+                <div className='dropdown-block' onClick={this.toggleLocationDropdown}>
+                  <label className='dropdown-label label'>
+                    <span>Where</span>
+                  </label>
+                  <a className='button'>
+                    <span>{this.state.locationFilter ? this.state.locationFilter.label : "Select a city"}</span>
+                  </a>
+                  <div className={"dropdown-container " + (this.state.locationDropdownOpen ? "is-open" : null)}>
+                    <div className='dropdown'>
+                      <button className='button label' data-arg1="all" data-arg2="All" onClick={this.setLocation}>All</button>    
+                      <button className='button label' data-arg1="budapest" data-arg2="Budapest" onClick={this.setLocation}>Budapest</button>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </Columns.Column>
-            <Columns.Column>
-              <div className='dropdown-block' onClick={this.toggleBeanDropdown}>
-                <label className='dropdown-label label'>
-                  <span>Bean</span>
-                </label>
-                <a className='button'>
-                  <span>{this.state.beanFilter ? this.state.beanFilter.label : "Select a bean type"}</span>
-                </a>
-                <div className={"dropdown-container " + (this.state.beanDropdownOpen ? "is-open" : null)}>
-                  <div className='dropdown'>
-                    <button className='button label' data-arg1="all" data-arg2="All" onClick={this.setBeanType}>All</button>
-                    <button className='button label' data-arg1="bean_roast_light" data-arg2="Light" onClick={this.setBeanType}>Light</button>
-                    <button className='button label' data-arg1="bean_roast_medium" data-arg2="Medium" onClick={this.setBeanType}>Medium</button>
-                    <button className='button label' data-arg1="bean_roast_dark" data-arg2="Dark" onClick={this.setBeanType}>Dark</button>
+              </Columns.Column>
+              <Columns.Column>
+                <div className='dropdown-block' onClick={this.toggleBeanDropdown}>
+                  <label className='dropdown-label label'>
+                    <span>Bean</span>
+                  </label>
+                  <a className='button'>
+                    <span>{this.state.beanFilter ? this.state.beanFilter.label : "Select a bean type"}</span>
+                  </a>
+                  <div className={"dropdown-container " + (this.state.beanDropdownOpen ? "is-open" : null)}>
+                    <div className='dropdown'>
+                      <button className='button label' data-arg1="all" data-arg2="All" onClick={this.setBeanType}>All</button>
+                      <button className='button label' data-arg1="bean_roast_light" data-arg2="Light" onClick={this.setBeanType}>Light</button>
+                      <button className='button label' data-arg1="bean_roast_medium" data-arg2="Medium" onClick={this.setBeanType}>Medium</button>
+                      <button className='button label' data-arg1="bean_roast_dark" data-arg2="Dark" onClick={this.setBeanType}>Dark</button>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </Columns.Column>
-            <Columns.Column>
-              <div className='dropdown-block' onClick={this.toggleMethodDropdown}>
-                <label className='dropdown-label label'>
-                  <span>Method</span>
-                </label>
-                <a className='button'>
-                  <span>{this.state.methodFilter ? this.state.methodFilter.label : "Select a brew method"}</span>
-                </a>
-                <div className={"dropdown-container " + (this.state.methodDropdownOpen ? "is-open" : null)}>
-                  <div className='dropdown'>
-                    <button className='button label' data-arg1="all" data-arg2="All" onClick={this.setMethodType}>All</button>
-                    <button className='button label' data-arg1="brew_method_espresso" data-arg2="Espresso" onClick={this.setMethodType}>Espresso</button>
-                    <button className='button label' data-arg1="brew_method_aeropress" data-arg2="Aeropress" onClick={this.setMethodType}>Aeropress</button>
-                    <button className='button label' data-arg1="brew_method_pourover" data-arg2="Pour Over" onClick={this.setMethodType}>Pour Over</button>
-                    <button className='button label' data-arg1="brew_method_syphon" data-arg2="Syphon" onClick={this.setMethodType}>Syphon</button>
-                    <button className='button label' data-arg1="brew_method_fullimmersion" data-arg2="Full Immersion" onClick={this.setMethodType}>Full Immersion</button>
+              </Columns.Column>
+              <Columns.Column>
+                <div className='dropdown-block' onClick={this.toggleMethodDropdown}>
+                  <label className='dropdown-label label'>
+                    <span>Method</span>
+                  </label>
+                  <a className='button'>
+                    <span>{this.state.methodFilter ? this.state.methodFilter.label : "Select a brew method"}</span>
+                  </a>
+                  <div className={"dropdown-container " + (this.state.methodDropdownOpen ? "is-open" : null)}>
+                    <div className='dropdown'>
+                      <button className='button label' data-arg1="all" data-arg2="All" onClick={this.setMethodType}>All</button>
+                      <button className='button label' data-arg1="brew_method_espresso" data-arg2="Espresso" onClick={this.setMethodType}>Espresso</button>
+                      <button className='button label' data-arg1="brew_method_aeropress" data-arg2="Aeropress" onClick={this.setMethodType}>Aeropress</button>
+                      <button className='button label' data-arg1="brew_method_pourover" data-arg2="Pour Over" onClick={this.setMethodType}>Pour Over</button>
+                      <button className='button label' data-arg1="brew_method_syphon" data-arg2="Syphon" onClick={this.setMethodType}>Syphon</button>
+                      <button className='button label' data-arg1="brew_method_fullimmersion" data-arg2="Full Immersion" onClick={this.setMethodType}>Full Immersion</button>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </Columns.Column>
-            <Columns.Column>
-              <div className='dropdown-block' onClick={this.toggleRoasterDropdown}>
-                <label className='dropdown-label label'>
-                  <span>Roaster</span>
-                </label>
-                <a className='button'>
-                  <span>{this.state.roasterFilter ? this.state.roasterFilter.label : "Select a roaster"}</span>
-                </a>
-                <div className={"dropdown-container " + (this.state.roasterDropdownOpen ? "is-open" : null)}>
-                  <div className='dropdown'>
-                    <button className='button label' data-arg1="all" data-arg2="All" onClick={this.setRoaster}>All</button>
-                    {!this.state.isLoading && this.renderRoasterList(_roasters)}
+              </Columns.Column>
+              <Columns.Column>
+                <div className='dropdown-block' onClick={this.toggleRoasterDropdown}>
+                  <label className='dropdown-label label'>
+                    <span>Roaster</span>
+                  </label>
+                  <a className='button'>
+                    <span>{this.state.roasterFilter ? this.state.roasterFilter.label : "Select a roaster"}</span>
+                  </a>
+                  <div className={"dropdown-container " + (this.state.roasterDropdownOpen ? "is-open" : null)}>
+                    <div className='dropdown'>
+                      <button className='button label' data-arg1="all" data-arg2="All" onClick={this.setRoaster}>All</button>
+                      {!this.state.isLoading && this.renderRoasterList(_roasters)}
+                    </div>
                   </div>
                 </div>
-              </div>
-            </Columns.Column>
-          </Columns>
-        </Box>
+              </Columns.Column>
+            </Columns>
+          </Box>
 
-        <Box className="resultsContainer">
-          <Columns breakpoint="desktop">
-            {!this.state.isLoading && this.renderCafeList(_cafes)}
-          </Columns>
-        </Box>
-      </Container>
+          <Box className="resultsContainer">
+            <Columns breakpoint="desktop">
+              {!this.state.isLoading && this.renderCafeList(_cafes)}
+            </Columns>
+          </Box>
+        </Container>
+      </div>
     );
   }
 }

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -86,7 +86,7 @@ export default class Home extends Component {
 
   renderCafeList(cafes) {
     if (cafes.length > 0) {
-      return cafes.map((cafe) =>
+      return cafes.map((cafe) => 
         <Col lg="3" key={cafe.uid} className="resultsCard">
           <div className="imageCard">
             <img src={cafe.extra_thumbnail} alt="Thumbnail" />


### PR DESCRIPTION
Task list:
- [x] Add routing for detail page: `{city}/{normalized-cafe-name}`
- [x] Pass-over data from home page to detail page: `{cafeId}`
- [x] Load data via API (`api.thirdwavelist.com/v1/cafe/{id}`) when available
- [x] Load data via API from `{normalized-cafe-name}` and `{city}` (MR in other project)
- [x] Import Mapbox GL JS  and show map based on _dummy_ coordinates
- [x] Show data from cafe API response about bean and gear (`api.thirdwavelist.com/v1/cafe/{id}`)
- [x] **Enrich database** with `lat,long` values for cheapest[1] way of showing map
- [x] Replace placeholder in "Directions" button to open Google Maps: `cafe.city` and `cafe.extra_google_place_id` from cafe API response (`api.thirdwavelist.com/v1/cafe/{id}`)
- ~[ ] Make map go fullscreen on click~ (for now removed as map will be moved around)
- [x] Instagram, Facebook social buttons
- [x] Make layout pixel perfect (sort of 😅)

_[1] no need for reverse geo-coding on the fly, as we are rate limited_