### PR TITLE
Updated use of API to reflect recent changes of moving from ES to DDB

### DIFF
--- a/src/containers/CafeDetail.js
+++ b/src/containers/CafeDetail.js
@@ -25,17 +25,14 @@ export default class CafeDetail extends Component {
             this.setState({ cafe: cafeCallResponse });
             this.setState({ isLoading: false });
         } catch (err) {
+            console.log(this.props.location.pathname.split('/'));
             var pathSegments = this.props.location.pathname.split('/');
-            const cafeName = pathSegments[1]
-            const cityName = pathSegments[2]
+            const cityName = pathSegments[1]
+            const cafeName = pathSegments[2]
             const cafeCallResponse = await this.cafeByName(cafeName, cityName);
             this.setState({ cafe: cafeCallResponse });
             this.setState({ isLoading: false });
         }
-    }
-
-    toggleFullscreen() {
-        console.log("fullscreen mode toggled");
     }
 
     cafeById(cafeId) {

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -93,7 +93,7 @@ export default class Home extends Component {
             <span className="imageTitle">{cafe.name}</span>
             {/* <div className="after" onClick={() => {location.href=this.getLinkFrom(cafe)}}> */}
             <Link to = {{ 
-                pathname: '/'+cafe.city.toLowerCase()+'/'+cafe.name.replace(/\s+/g, '-').toLowerCase(),
+                pathname: '/'+cafe.city.toLowerCase()+'/'+cafe.extra_url_name.toLowerCase(),
                 state:{ cafeId: cafe.uid }
               }}
               className="after">


### PR DESCRIPTION
Implementing https://github.com/anthonymonori/thirdwavelist-api/pull/1 we figured out after staging the ElasticSearch approach that it was quite expensive to run a search every single time for those nice-looking detail page URLs, hence we reverted it and added extra data to the database where we could define a URL for the detail pages.